### PR TITLE
Добавление режима отладки в заголовок

### DIFF
--- a/addins/configCaption.js
+++ b/addins/configCaption.js
@@ -23,7 +23,7 @@ var form;
 var sVersion = env.sVersion;
 var v8Version = env.v8Version;
 var arch = env.arch;
-var debugTitle = "*** РЕЖИМ ОТЛАДКИ *** ";
+var debugTitle = "*** ОТЛАДКА Снегопат *** ";
 
 events.connect(windows, "onChangeTitles", SelfScript.self);
 function setCaption(mainTitle, additionalTitle) {

--- a/addins/configCaption.js
+++ b/addins/configCaption.js
@@ -23,10 +23,20 @@ var form;
 var sVersion = env.sVersion;
 var v8Version = env.v8Version;
 var arch = env.arch;
+var debugTitle = "*** РЕЖИМ ОТЛАДКИ *** ";
+
 events.connect(windows, "onChangeTitles", SelfScript.self);
 function setCaption(mainTitle, additionalTitle) {
     var mainTitleShort = mainTitle.replace(/^Конфигуратор - /, "");
     windows.caption = eval(captionExpr);
+    
+    // Временное решение, после одобрения PR и пересборки в новый релиз snegopat_modul/src/ts/std/std.ts нужно переписать на
+	// if (stdlib.isDebug) или Александр добавит env.isDebug в api.h в класс as_env после чего можно будет
+    // переписать на if (env.isDebug) и убрать не нужный код проверяющий coreas-tracefunctions в modul/src/ts/std/std.ts если был одобрен его PR
+	if (profileRoot.getValue("CmdLine/OriginalCmdLine").toLowerCase().indexOf("-coreas-tracefunctions 1") > 0)
+	{
+		windows.caption = debugTitle + eval(captionExpr);
+	}
 }
 function ibName() {
     return stdlib.ibName();


### PR DESCRIPTION
Добавлена информация о режиме отладки в заголовок конфигуратора.
Временное решение, после одобрения PR и пересборки (если таковое случится) в новый релиз snegopat_modul/src/ts/std/std.ts нужно переписать на
if (stdlib.isDebug) или Александр добавит env.isDebug в api.h в класс as_env после чего можно будет
переписать на if (env.isDebug) и убрать не нужный код проверяющий coreas-tracefunctions в modul/src/ts/std/std.ts если был одобрен его PR и PR этого скрипта