### PR TITLE
Отключение безопасного режима при создании ВнешнейОбработки (DebugInstruments.js)

### DIFF
--- a/addins/DebugInstruments.js
+++ b/addins/DebugInstruments.js
@@ -301,7 +301,7 @@ DebugInstruments = ScriptForm.extend({
         if (this.form.useEpf){
             var f = v8New('File', getAbsolutePath(this.form.pathToEpf));
             if (f.IsFile() && f.Exist()){
-                expText = 'ВнешниеОбработки.Создать("' +f.FullName +'").'
+                expText = 'ВнешниеОбработки.Создать("' +f.FullName +'", Ложь).'
             }
         }
         return expText + text;


### PR DESCRIPTION
Отключен безопасный режим при создании ВнешнейОбработки, в противном случае не всегда успешно создается на стороне сервера.