### PR TITLE
Отключение безопасного режима при создании ВнешнейОбработки (debugHelpers.js)

### DIFF
--- a/addins/debugHelpers.js
+++ b/addins/debugHelpers.js
@@ -81,7 +81,7 @@ function onDoModal(dlgInfo) {
             if (!exprCtrl.value.match(/^\s*$/)) 
             {            
                 if (!params.commandCheck) {
-                    exprCtrl.value = 'ВнешниеОбработки.Создать("' + params.path + '").Отладить(' + exprCtrl.value + ', ' + (params.doModal ? 'Истина' :  'Ложь') + ')';
+                    exprCtrl.value = 'ВнешниеОбработки.Создать("' + params.path + '", Ложь).Отладить(' + exprCtrl.value + ', ' + (params.doModal ? 'Истина' :  'Ложь') + ')';
                 } else {
                     exprCtrl.value = ''+ params.command + '(' + exprCtrl.value + ', ' + (params.doModal ? 'Истина' :  'Ложь') + ')';
                 }


### PR DESCRIPTION
Отключен безопасный режим при создании ВнешнейОбработки, в противном случае не всегда успешно создается на стороне сервера.