### PR TITLE
Исправление ошибки

### DIFF
--- a/engine/com_metadata.as
+++ b/engine/com_metadata.as
@@ -799,6 +799,8 @@ IMDContainer&& editedMetaDataCont() {
 #if test = 0
     IConfigMngrUI&& pmdUI;
     getMDEditService().getTemplatesMainConfigMngrUI(pmdUI);
+    if (!checkInterface(&&pmdUI))
+		return null;
     return pmdUI.getMDCont();
 #else
     IMDEditService&& mdes = getMDEditService();


### PR DESCRIPTION
При обращении к metadata.current в скриптах в момент закрытия конфигуратора возникала ошибка.